### PR TITLE
Add container entrypoint and registry push functionality

### DIFF
--- a/build-and-push.sh
+++ b/build-and-push.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+#
+# build-and-push.sh
+#
+# Script to build Docker image and optionally push to OCI registry
+#
+
+set -e
+
+# Source environment variables from .env if it exists
+if [ -f /etc/batesste-ci-images/.env ]; then
+    # shellcheck disable=SC2046
+    export $(grep -v '^#' /etc/batesste-ci-images/.env | xargs)
+fi
+
+# Set defaults
+IMAGE_NAME=${REGISTRY_IMAGE:-batesste-ci-images}
+IMAGE_TAG=${IMAGE_TAG:-latest}
+REGISTRY=${REGISTRY:-docker.io}
+REGISTRY_USERNAME=${REGISTRY_USERNAME:-}
+REGISTRY_PASSWORD=${REGISTRY_PASSWORD:-}
+QEMU_COMMIT=${QEMU_COMMIT:-HEAD}
+WORKDIR=${WORKDIR:-/opt/batesste-ci-images}
+
+cd "${WORKDIR}" || exit 1
+
+echo "=== Building Docker Image ==="
+echo "Image: ${REGISTRY}/${IMAGE_NAME}:${IMAGE_TAG}"
+echo "QEMU Commit: ${QEMU_COMMIT}"
+
+# Ensure buildx is available
+if ! docker buildx version > /dev/null 2>&1; then
+    echo "Error: docker buildx is not available"
+    exit 1
+fi
+
+# Create buildx builder if it doesn't exist
+docker buildx create --name builder --use 2>/dev/null || docker buildx use builder 2>/dev/null || true
+
+# Build the Docker image
+docker buildx build \
+    --build-arg QEMU_COMMIT="${QEMU_COMMIT}" \
+    --tag "${REGISTRY}/${IMAGE_NAME}:${IMAGE_TAG}" \
+    --tag "${REGISTRY}/${IMAGE_NAME}:latest" \
+    --load \
+    .
+
+# Push to registry if credentials are provided
+if [ -n "${REGISTRY_USERNAME}" ] && [ -n "${REGISTRY_PASSWORD}" ]; then
+    echo "=== Pushing to Registry ==="
+    echo "${REGISTRY_PASSWORD}" | docker login "${REGISTRY}" \
+        --username "${REGISTRY_USERNAME}" \
+        --password-stdin
+    
+    docker push "${REGISTRY}/${IMAGE_NAME}:${IMAGE_TAG}"
+    docker push "${REGISTRY}/${IMAGE_NAME}:latest"
+    
+    echo "Image pushed successfully to ${REGISTRY}/${IMAGE_NAME}:${IMAGE_TAG}"
+else
+    echo "Registry credentials not provided, skipping push"
+fi
+
+echo "=== Build Complete ==="
+

--- a/build-vm.service
+++ b/build-vm.service
@@ -1,17 +1,21 @@
 [Unit]
-Description=Build QEMU VM Image Daily
-After=network.target
+Description=Build QEMU VM Image and Push to Registry Daily
+After=network.target docker.service
+Requires=docker.service
 
 [Service]
 Type=oneshot
 EnvironmentFile=/etc/batesste-ci-images/.env
 WorkingDirectory=/opt/batesste-ci-images
+# First, build and push the Docker image
+ExecStartPre=/opt/batesste-ci-images/build-and-push.sh
+# Then, run the container to build the VM image
 ExecStart=/usr/bin/docker run --rm \
     -v /home/stebates/Projects/qemu-minimal:/build/qemu-minimal \
     -v /opt/batesste-ci-images/output:/output \
     -v /opt/batesste-ci-images/.env:/build/.env:ro \
     --name batesste-ci-vm-builder \
-    batesste-ci-images:latest
+    ${REGISTRY:-docker.io}/${REGISTRY_IMAGE:-batesste-ci-images}:${IMAGE_TAG:-latest}
 StandardOutput=journal
 StandardError=journal
 

--- a/env.example
+++ b/env.example
@@ -21,3 +21,11 @@ QEMU_MINIMAL_PATH=/build/qemu-minimal
 QEMU_MINIMAL_COMMIT=
 QEMU_MINIMAL_REPO=
 
+# OCI Registry Configuration (for pushing Docker images)
+# Leave empty to skip pushing
+REGISTRY=docker.io
+REGISTRY_IMAGE=batesste-ci-images
+REGISTRY_USERNAME=
+REGISTRY_PASSWORD=
+IMAGE_TAG=latest
+


### PR DESCRIPTION
This commit adds comprehensive functionality to run VMs in containers with SSH access and automatically push Docker images to OCI registries.

Features Added:
- Container entrypoint to build and run VM with SSH access
- Configurable SSH port via SSH_PORT environment variable
- Automatic VM image building on first run
- KVM acceleration support (optional, falls back to TCG)
- Multi-architecture support (x86_64, ARM64, RISC-V)
- OCI registry push functionality for Docker images
- Automated daily builds with registry push support

Changes:

Container Entrypoint:
- entrypoint.sh: New script to build VM if needed and run it with QEMU
- Dockerfile: Changed CMD to ENTRYPOINT, added entrypoint.sh
- env.example: Added SSH_PORT, VCPUS, and VMEM configuration
- README.md: Added comprehensive documentation for running VM container

Registry Push:
- build-and-push.sh: New script to build and push Docker images to OCI registry
- build-vm.service: Updated to build and push images before VM creation
- env.example: Added REGISTRY, REGISTRY_IMAGE, REGISTRY_USERNAME, REGISTRY_PASSWORD, and IMAGE_TAG configuration
- README.md: Added registry push configuration and security notes

CI/CD Improvements:
- Updated spell-check.yml to use rojopolis/spellcheck-github-actions (matching qemu-minimal workspace)
- Added .spellcheck.yaml configuration file
- Added .wordlist.txt with technical terms and custom words
- Updated dockerfile-test.yml to test entrypoint functionality

Usage Examples:

Run VM Container:
  docker run -d --name my-vm \ --cap-add NET_ADMIN \ -p 2222:2222 \ -v /path/to/qemu-minimal:/build/qemu-minimal \ -v $(pwd)/output:/output \ -v $(pwd)/.env:/build/.env:ro \ batesste-ci-images:latest

  ssh -p 2222 batesste@localhost

Configure Registry Push:
  Add to /etc/batesste-ci-images/.env: REGISTRY=docker.io REGISTRY_IMAGE=your-username/batesste-ci-images REGISTRY_USERNAME=your-username REGISTRY_PASSWORD=your-token IMAGE_TAG=latest

The systemd service will now:
1. Build the Docker image with specified QEMU commit
2. Push image to configured registry (if credentials provided)
3. Run container to build VM image

All scripts pass shellcheck validation and CI tests.