### PR TITLE
Improve build-and-push.sh with enhanced security and flexibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# Ignore any PA token files.
+*.token
+# Ignore the .env file.
+.env

--- a/README.md
+++ b/README.md
@@ -2,14 +2,9 @@
 
 This repository contains a collection of Docker images for CI/CD and
 development workflows. Each image is self-contained in its own directory
-with its own Dockerfile and supporting scripts.
-
-## Overview
-
-This repository supports multiple Docker images, each in its own directory.
-Each image may have different purposes and requirements. See the
-individual image directories for specific documentation and usage
-instructions.
+with its own Dockerfile and supporting scripts. We also include a systemd
+directory that enables a systemd service based flow for the automatic updating
+and pushing of these images.
 
 ## Available Images
 
@@ -53,6 +48,12 @@ Or build a specific image:
 
 ```bash
 ./build-and-push.sh qemu-libvfio-user
+```
+
+To specify a password file for registry authentication:
+
+```bash
+./build-and-push.sh qemu-libvfio-user --password-file /path/to/password.txt
 ```
 
 You can also build images directly with Docker:
@@ -101,11 +102,21 @@ Common configuration variables:
 
 - `REGISTRY`: OCI registry URL (default: `docker.io` for Docker Hub)
 - `REGISTRY_IMAGE`: Base image name in registry (default: `batesste-ci-images`)
-  - Final image names will be `{REGISTRY_IMAGE}-{image-directory}` (e.g.,
-    `batesste-ci-images-qemu-libvfio-user`)
-- `REGISTRY_USERNAME`: Registry username for authentication
+  - Final image names will be `{REGISTRY_USERNAME}/{REGISTRY_IMAGE}-{image-directory}`
+    (e.g., `username/batesste-ci-images-qemu-libvfio-user`)
+  - If `REGISTRY_IMAGE` contains a `/`, it's used as-is
+  - If `REGISTRY_USERNAME` is set, it's prepended automatically
+- `REGISTRY_USERNAME`: Registry username for authentication (required for Docker Hub)
 - `REGISTRY_PASSWORD`: Registry password or token for authentication
+  - Can be a direct password or a path to a file containing the password
+- `REGISTRY_PASSWORD_FILE`: Alternative way to specify password file path
 - `IMAGE_TAG`: Image tag to use (default: `latest`)
+- `WORKDIR`: Working directory for builds (defaults to script directory)
+
+The `build-and-push.sh` script also supports:
+- `--password-file FILE`: Command-line option to specify password file
+- Automatically reads `.env` from script directory, current directory, or
+  `/etc/batesste-ci-images/.env` (in that order)
 
 Image-specific variables are documented in each image's directory. For
 example, the `qemu-libvfio-user` image may use variables like `QEMU_COMMIT`,

--- a/build-and-push.sh
+++ b/build-and-push.sh
@@ -3,32 +3,99 @@
 # build-and-push.sh
 #
 # Script to build Docker image and optionally push to OCI registry
-# Usage: build-and-push.sh [IMAGE_NAME]
+# Usage: build-and-push.sh [IMAGE_NAME] [--password-file FILE]
 #   IMAGE_NAME: Name of the image directory (e.g., qemu-libvfio-user)
 #               If not provided, builds all images
+#   --password-file FILE: Path to file containing registry password
+#                         (alternative to REGISTRY_PASSWORD env var)
+#
+# Password can be provided via:
+#   - REGISTRY_PASSWORD environment variable (direct password or file path)
+#   - REGISTRY_PASSWORD_FILE environment variable (file path)
+#   - --password-file command line option
+#   If REGISTRY_PASSWORD points to an existing file, it will be read as a file
 #
 
 set -e
 
 # Source environment variables from .env if it exists
-if [ -f /etc/batesste-ci-images/.env ]; then
+# Check multiple locations: local .env, then system-wide config
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [ -f "${SCRIPT_DIR}/.env" ]; then
+    # shellcheck disable=SC2046
+    export $(grep -v '^#' "${SCRIPT_DIR}/.env" | xargs)
+elif [ -f .env ]; then
+    # shellcheck disable=SC2046
+    export $(grep -v '^#' .env | xargs)
+elif [ -f /etc/batesste-ci-images/.env ]; then
     # shellcheck disable=SC2046
     export $(grep -v '^#' /etc/batesste-ci-images/.env | xargs)
 fi
+
+# Parse command line arguments
+IMAGE_NAME_ARG=""
+PASSWORD_FILE=""
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --password-file)
+            PASSWORD_FILE="$2"
+            shift 2
+            ;;
+        --password-file=*)
+            PASSWORD_FILE="${1#*=}"
+            shift
+            ;;
+        *)
+            if [ -z "$IMAGE_NAME_ARG" ]; then
+                IMAGE_NAME_ARG="$1"
+            fi
+            shift
+            ;;
+    esac
+done
 
 # Set defaults
 IMAGE_TAG=${IMAGE_TAG:-latest}
 REGISTRY=${REGISTRY:-docker.io}
 REGISTRY_USERNAME=${REGISTRY_USERNAME:-}
 REGISTRY_PASSWORD=${REGISTRY_PASSWORD:-}
+REGISTRY_PASSWORD_FILE=${REGISTRY_PASSWORD_FILE:-}
 QEMU_COMMIT=${QEMU_COMMIT:-HEAD}
-WORKDIR=${WORKDIR:-/opt/batesste-ci-images}
+
+# Determine WORKDIR: use script directory if WORKDIR not set or doesn't exist
+# (SCRIPT_DIR already set above)
+if [ -z "${WORKDIR}" ]; then
+    WORKDIR="${SCRIPT_DIR}"
+elif [ ! -d "${WORKDIR}" ]; then
+    echo "Warning: WORKDIR ${WORKDIR} does not exist, using script directory: ${SCRIPT_DIR}"
+    WORKDIR="${SCRIPT_DIR}"
+fi
+
+# Determine password source: command line > env file > env direct
+if [ -n "${PASSWORD_FILE}" ]; then
+    REGISTRY_PASSWORD_FILE="${PASSWORD_FILE}"
+elif [ -z "${REGISTRY_PASSWORD_FILE}" ] && [ -n "${REGISTRY_PASSWORD}" ]; then
+    # Check if REGISTRY_PASSWORD is a file path
+    if [ -f "${REGISTRY_PASSWORD}" ]; then
+        REGISTRY_PASSWORD_FILE="${REGISTRY_PASSWORD}"
+        REGISTRY_PASSWORD=""
+    fi
+fi
+
+# Read password from file if specified
+if [ -n "${REGISTRY_PASSWORD_FILE}" ]; then
+    if [ ! -f "${REGISTRY_PASSWORD_FILE}" ]; then
+        echo "Error: Password file not found: ${REGISTRY_PASSWORD_FILE}"
+        exit 1
+    fi
+    REGISTRY_PASSWORD=$(cat "${REGISTRY_PASSWORD_FILE}" | tr -d '\n\r')
+fi
 
 cd "${WORKDIR}" || exit 1
 
 # Get image name from argument or build all
-if [ -n "$1" ]; then
-    IMAGE_DIRS=("$1")
+if [ -n "${IMAGE_NAME_ARG}" ]; then
+    IMAGE_DIRS=("${IMAGE_NAME_ARG}")
 else
     # Find all directories with Dockerfiles
     mapfile -t IMAGE_DIRS < <(find . -maxdepth 2 -name "Dockerfile" \
@@ -59,7 +126,27 @@ for IMAGE_DIR in "${IMAGE_DIRS[@]}"; do
         continue
     fi
 
-    IMAGE_NAME=${REGISTRY_IMAGE:-batesste-ci-images}-${IMAGE_DIR}
+    # Construct image name: if REGISTRY_IMAGE contains /, use as-is,
+    # otherwise prepend REGISTRY_USERNAME if available
+    if [ -n "${REGISTRY_IMAGE}" ]; then
+        if [[ "${REGISTRY_IMAGE}" == */* ]]; then
+            # Already contains username/repo format
+            IMAGE_NAME=${REGISTRY_IMAGE}-${IMAGE_DIR}
+        elif [ -n "${REGISTRY_USERNAME}" ]; then
+            # Prepend username
+            IMAGE_NAME=${REGISTRY_USERNAME}/${REGISTRY_IMAGE}-${IMAGE_DIR}
+        else
+            # No username available, use as-is (may fail for Docker Hub)
+            IMAGE_NAME=${REGISTRY_IMAGE}-${IMAGE_DIR}
+        fi
+    else
+        # Default: use username if available, otherwise just repo name
+        if [ -n "${REGISTRY_USERNAME}" ]; then
+            IMAGE_NAME=${REGISTRY_USERNAME}/batesste-ci-images-${IMAGE_DIR}
+        else
+            IMAGE_NAME=batesste-ci-images-${IMAGE_DIR}
+        fi
+    fi
     
     echo "=== Building Docker Image ==="
     echo "Image: ${REGISTRY}/${IMAGE_NAME}:${IMAGE_TAG}"

--- a/qemu-libvfio-user/Dockerfile
+++ b/qemu-libvfio-user/Dockerfile
@@ -53,8 +53,9 @@ RUN chmod +x /build/build-vm.sh /build/entrypoint.sh
 
 # Set default environment variables
 # Note: VM_NAME defaults to ${USERNAME}-ci-vm in build-vm.sh
+# Note: PASSWORD should be provided at runtime via environment variable
+#       (defaults to 'changeme' in scripts if not set)
 ENV USERNAME=batesste
-ENV PASSWORD=changeme
 ENV QEMU_PATH=/opt/qemu/bin/
 ENV SSH_PORT=2222
 ENV VCPUS=2


### PR DESCRIPTION
- Add support for password files via --password-file option
  - Password can be provided via command line, REGISTRY_PASSWORD_FILE env var, or REGISTRY_PASSWORD pointing to a file path
  - Automatically detects if REGISTRY_PASSWORD is a file path
- Fix WORKDIR handling to not require /opt directory
  - Defaults to script directory if WORKDIR not set or doesn't exist
  - Makes script portable and works without system-wide installation
- Add support for local .env file loading
  - Checks script directory, current directory, then system-wide config
  - Enables easier local development and testing
- Fix Docker Hub image naming to include username
  - Automatically prepends REGISTRY_USERNAME if REGISTRY_IMAGE doesn't contain /
  - Fixes "denied: requested access to the resource is denied" errors
  - Supports both username/repo and repo-only formats
- Remove PASSWORD from Dockerfile ENV to fix security warning
  - PASSWORD now only provided at runtime via environment variables
  - Scripts already have defaults, so functionality unchanged
  - Addresses Docker BuildKit SecretsUsedInArgOrEnv warning
- Add .env to .gitignore to prevent accidental commits
- Update README.md with new features and usage examples
  - Document password file options
  - Update image naming format documentation
  - Add examples for --password-file usage

These changes improve security, portability, and usability of the build script while maintaining backward compatibility.