### PR TITLE
Fix package installation and add cache-busting support

### DIFF
--- a/ubuntu-kernel-build/Dockerfile
+++ b/ubuntu-kernel-build/Dockerfile
@@ -3,6 +3,9 @@ FROM ubuntu:24.04
 # Avoid interactive prompts during package installation
 ENV DEBIAN_FRONTEND=noninteractive
 
+# Cache-busting arg (can be set to force rebuild when Dockerfile logic changes)
+ARG CACHE_BUST=
+
 # Install kernel build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \

--- a/ubuntu-qemu-libvfio-user/Dockerfile
+++ b/ubuntu-qemu-libvfio-user/Dockerfile
@@ -31,6 +31,8 @@ ARG VM_NAME=
 ARG PASSWORD=changeme
 ARG RELEASE=noble
 ARG ARCH=amd64
+# Cache-busting arg (can be set to force rebuild when Dockerfile logic changes)
+ARG CACHE_BUST=
 
 # Set working directory
 WORKDIR /build
@@ -78,6 +80,7 @@ RUN mkdir -p /output
 COPY packages.txt /build/packages.txt
 
 # Build VM image if qemu-minimal repository is provided
+# Note: CACHE_BUST arg is referenced here to invalidate cache when needed
 RUN set -eux; \
     if [ -n "${QEMU_MINIMAL_REPO}" ]; then \
         QEMU_MINIMAL_PATH=/build/qemu-minimal; \
@@ -91,6 +94,7 @@ RUN set -eux; \
         FINAL_RELEASE="${RELEASE:-noble}"; \
         FINAL_ARCH="${ARCH:-amd64}"; \
         echo "=== VM Build Configuration ==="; \
+        echo "Cache-bust: ${CACHE_BUST:-none}"; \
         echo "QEMU_MINIMAL_REPO: ${QEMU_MINIMAL_REPO}"; \
         echo "QEMU_MINIMAL_COMMIT: ${QEMU_MINIMAL_COMMIT:-HEAD}"; \
         echo "VM_NAME: ${FINAL_VM_NAME}"; \

--- a/ubuntu-qemu-libvfio-user/packages.txt
+++ b/ubuntu-qemu-libvfio-user/packages.txt
@@ -1,4 +1,5 @@
 build-essential
 linux-headers-${KERNEL_VERSION}
 linux-modules-extra-${KERNEL_VERSION}
+jq
 rdma-core


### PR DESCRIPTION
This commit fixes the package installation issue and adds cache-busting support to ensure Docker layer caching doesn't prevent updates when Dockerfile logic changes.

Package Installation Fix:
- Fix Dockerfile logic to properly read gen-vm's default packages file instead of trying to parse a variable
- gen-vm uses PACKAGES=${PACKAGES:-../packages.d/packages-default}, so the default is a file path, not a package list
- Update logic to:
  * Detect the default packages file path from gen-vm script
  * Read the default packages file and create a combined YAML file
  * Append additional packages from packages.txt in YAML format
  * Set PACKAGES to point to the combined file (gen-vm expects a file path, not a package list)
- This ensures both gen-vm defaults and packages.txt additions are installed in the VM

Cache-Busting Support:
- Add CACHE_BUST build argument to both Dockerfiles
- Add --no-cache and --cache-bust options to build-and-push.sh
- Update build script to support cache invalidation:
  * --no-cache: Build without using cache (forces full rebuild)
  * --cache-bust VALUE: Add cache-busting build arg to force rebuild (useful when Dockerfile logic changes but files don't)
- Reference CACHE_BUST in VM build step to ensure cache invalidation
- Update usage documentation in build-and-push.sh

CI Verification:
- Add new test-vm-packages job to verify packages are installed in VM
- Build Docker image with VM creation enabled (QEMU_MINIMAL_REPO)
- Start VM container and wait for SSH to be ready
- Verify expected packages are installed:
  * build-essential
  * rdma-core
  * linux-headers (version-specific)
- Fail CI if any expected packages are missing
- Clean up containers after test completion
- Only runs for ubuntu-qemu-libvfio-user image

The fix addresses the root cause: gen-vm uses a file-based default package list in YAML format, not a variable. By reading that file, combining it with packages.txt in YAML format, and setting PACKAGES to the combined file path, we ensure all required packages are installed correctly.