### PR TITLE
jq: Move the jq package into the Dockerfile

### DIFF
--- a/ubuntu-qemu-libvfio-user/Dockerfile
+++ b/ubuntu-qemu-libvfio-user/Dockerfile
@@ -7,6 +7,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     git \
+    jq \
     python3 \
     python3-venv \
     ninja-build \

--- a/ubuntu-qemu-libvfio-user/packages.txt
+++ b/ubuntu-qemu-libvfio-user/packages.txt
@@ -1,5 +1,4 @@
 build-essential
 linux-headers-${KERNEL_VERSION}
 linux-modules-extra-${KERNEL_VERSION}
-jq
 rdma-core


### PR DESCRIPTION
The jq package install needs to be in the Dockerfile and not in the packages.txt file.