### PR TITLE
ubuntu-rocm: Add a ROCm-based container generation

### DIFF
--- a/.github/workflows/dockerfile-test.yml
+++ b/.github/workflows/dockerfile-test.yml
@@ -2,13 +2,13 @@ name: Dockerfile Test
 
 on:
   push:
-    branches: [ main, master ]
+    branches: [main, master]
     paths:
       - '**/Dockerfile'
       - '**/entrypoint.sh'
       - '.github/workflows/dockerfile-test.yml'
   pull_request:
-    branches: [ main, master ]
+    branches: [main, master]
     paths:
       - '**/Dockerfile'
       - '**/entrypoint.sh'
@@ -55,8 +55,10 @@ jobs:
           cache-to: type=gha,mode=max
           build-args: |
             QEMU_COMMIT=HEAD
-            ${{ matrix.image == 'ubuntu-qemu-libvfio-user' && format('QEMU_MINIMAL_REPO=https://github.com/sbates130272/qemu-minimal.git') || '' }}
-            ${{ matrix.image == 'ubuntu-qemu-libvfio-user' && format('QEMU_MINIMAL_COMMIT=30c6d09265db2817f82e495aa5609e03fd0194a9') || '' }}
+            ${{ matrix.image == 'ubuntu-qemu-libvfio-user' &&
+              format('QEMU_MINIMAL_REPO=https://github.com/sbates130272/qemu-minimal.git') || '' }}
+            ${{ matrix.image == 'ubuntu-qemu-libvfio-user' &&
+              format('QEMU_MINIMAL_COMMIT=30c6d09265db2817f82e495aa5609e03fd0194a9') || '' }}
 
   test-entrypoint:
     name: Test Container Entrypoint
@@ -121,7 +123,11 @@ jobs:
     name: Test VM Packages
     runs-on: ubuntu-latest
     needs: [discover-images, build]
-    if: contains(fromJson(needs.discover-images.outputs.images), 'ubuntu-qemu-libvfio-user')
+    if: >
+      contains(
+        fromJson(needs.discover-images.outputs.images),
+        'ubuntu-qemu-libvfio-user'
+      )
     steps:
       - uses: actions/checkout@v4
 

--- a/README.md
+++ b/README.md
@@ -8,11 +8,13 @@ and pushing of these images.
 
 ## Available Images
 
-- **ubuntu-qemu-libvfio-user**: QEMU build with libvfio-user support for VM images
-  using qemu-minimal. See `ubuntu-qemu-libvfio-user/` for details.
+- **ubuntu-qemu-libvfio-user**: QEMU build with libvfio-user support for VM
+  images using qemu-minimal. See `ubuntu-qemu-libvfio-user/` for details.
 - **ubuntu-kernel-build**: Ubuntu-based image with tools for building Linux
   kernels and out-of-tree kernel modules. See `ubuntu-kernel-build/` for
   details.
+- **ubuntu-rocm**: Ubuntu-based image with AMD ROCm stack for GPU
+  development and CI/CD workflows. See `ubuntu-rocm/` for details.
 
 ## Project Structure
 
@@ -23,6 +25,10 @@ batesste-ci-images/
 │   └── entrypoint.sh
 ├── ubuntu-kernel-build/       # Kernel build environment
 │   ├── Dockerfile
+│   └── README.md
+├── ubuntu-rocm/               # ROCm development environment
+│   ├── Dockerfile
+│   ├── rocm-latest
 │   └── README.md
 ├── systemd/                    # Systemd service files
 │   ├── build-vm.service

--- a/ubuntu-rocm/Dockerfile
+++ b/ubuntu-rocm/Dockerfile
@@ -1,0 +1,107 @@
+FROM ubuntu:24.04
+
+# Avoid interactive prompts during package installation
+ENV DEBIAN_FRONTEND=noninteractive
+
+# ROCm version to install (default: latest)
+ARG ROCM_VERSION=latest
+ENV ROCM_VERSION=${ROCM_VERSION}
+ENV UBUNTU_CODENAME=noble
+
+# Cache-busting arg (can be set to force rebuild when Dockerfile logic
+# changes)
+ARG CACHE_BUST=
+
+# Install prerequisites
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    ca-certificates \
+    gnupg \
+    lsb-release \
+    python3-setuptools \
+    python3-wheel \
+    libstdc++-14-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy rocm-latest script
+COPY rocm-latest /usr/local/bin/rocm-latest
+RUN chmod +x /usr/local/bin/rocm-latest
+
+# Detect latest ROCm version if ROCM_VERSION is "latest"
+RUN set -eux; \
+    if [ "${ROCM_VERSION}" = "latest" ]; then \
+        DETECTED_ROCM=$(QUIET=true ONLY_ONE=ROCM \
+            /usr/local/bin/rocm-latest); \
+        DETECTED_AMDGPU=$(QUIET=true ONLY_ONE=AMDGPU \
+            /usr/local/bin/rocm-latest); \
+        echo "${DETECTED_ROCM}" > /tmp/rocm_version.txt; \
+        echo "${DETECTED_AMDGPU}" > /tmp/amdgpu_version.txt; \
+        echo "Detected ROCm version: ${DETECTED_ROCM}"; \
+        echo "Detected AMDGPU version: ${DETECTED_AMDGPU}"; \
+    else \
+        echo "${ROCM_VERSION}" > /tmp/rocm_version.txt; \
+        DETECTED_AMDGPU=$(QUIET=true ONLY_ONE=AMDGPU \
+            /usr/local/bin/rocm-latest); \
+        echo "${DETECTED_AMDGPU}" > /tmp/amdgpu_version.txt; \
+        echo "Using specified ROCm version: ${ROCM_VERSION}"; \
+        echo "Detected AMDGPU version: ${DETECTED_AMDGPU}"; \
+    fi
+
+RUN apt update && \
+    apt install -y \
+        curl \
+        gpg
+
+# Retrieve ROCm GPG key
+RUN curl https://repo.radeon.com/rocm/rocm.gpg.key | \
+    gpg --dearmor >> /etc/apt/keyrings/rocm.gpg
+
+# Manually setup ROCm Package Repos
+RUN cat <<EOF > /etc/apt/sources.list.d/rocm.list
+deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/${ROCM_VERSION} ${UBUNTU_CODENAME} main
+deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/amdgpu/${ROCM_VERSION}/ubuntu ${UBUNTU_CODENAME} main
+EOF
+
+RUN cat <<EOF > /etc/apt/preferences.d/rocm-pin-600
+Package: *
+Pin: release o=repo.radeon.com
+Pin-Priority: 600
+EOF
+
+# Development Dependencies
+RUN apt update && \
+    apt install -y \
+        clang \
+        cmake \
+        doxygen \
+        gdb \
+        git \
+        hip-dev \
+        libboost-program-options-dev \
+        libmount-dev \
+        librocthrust-dev \
+        libssl-dev \
+        llvm-dev \
+        rocm-llvm-dev
+
+# Configure system linker for ROCm
+RUN cat <<EOF > /etc/ld.so.conf.d/rocm.conf
+/opt/rocm/lib
+/opt/rocm/lib64
+EOF
+RUN ldconfig
+
+# Update PCIe ID tables (for new GPU support)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    pciutils \
+    && update-pciids \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set up environment variables
+ENV PATH=/opt/rocm/bin:${PATH}
+ENV LD_LIBRARY_PATH=/opt/rocm/lib:/opt/rocm/lib64:${LD_LIBRARY_PATH:-}
+
+# Set working directory
+WORKDIR /build
+
+CMD ["/bin/bash"]

--- a/ubuntu-rocm/README.md
+++ b/ubuntu-rocm/README.md
@@ -1,0 +1,119 @@
+# ubuntu-rocm
+
+Docker image for AMD ROCm development and CI/CD workflows.
+
+## Overview
+
+This image provides a complete environment for:
+- Building and running ROCm applications
+- HIP development and compilation
+- ROCm library development
+- CI/CD workflows requiring ROCm support
+
+## Base Image
+
+- Ubuntu 24.04
+
+## Installed Packages
+
+### ROCm Stack
+- `rocm` - Complete ROCm meta-package including:
+  - ROCm runtime libraries
+  - HIP compiler and runtime
+  - ROCm development tools
+  - ROCm libraries (rocBLAS, rocFFT, etc.)
+
+### Prerequisites
+- `libstdc++-14-dev` - C++ standard library development files
+- `python3-setuptools` - Python setuptools
+- `python3-wheel` - Python wheel package format
+- `pciutils` - PCI utilities (for GPU detection)
+
+## Build Arguments
+
+- `ROCM_VERSION` - ROCm version to install (default: `latest`)
+  - Set to `latest` to automatically detect and install the latest
+    available ROCm version
+  - Set to a specific version (e.g., `6.1.0`) to install that version
+- `CACHE_BUST` - Optional cache-busting argument to force rebuilds
+
+## Usage
+
+### Building the Image
+
+Build with default (latest) ROCm version:
+
+```bash
+docker build -f ubuntu-rocm/Dockerfile \
+  -t batesste-ci-images-ubuntu-rocm:latest \
+  ubuntu-rocm
+```
+
+Build with a specific ROCm version:
+
+```bash
+docker build -f ubuntu-rocm/Dockerfile \
+  --build-arg ROCM_VERSION=6.1.0 \
+  -t batesste-ci-images-ubuntu-rocm:6.1.0 \
+  ubuntu-rocm
+```
+
+Or use the build script:
+
+```bash
+./build-and-push.sh ubuntu-rocm
+```
+
+### Running ROCm Applications
+
+```bash
+docker run --rm -it \
+  --device=/dev/kfd \
+  --device=/dev/dri \
+  --security-opt seccomp=unconfined \
+  batesste-ci-images-ubuntu-rocm:latest \
+  rocminfo
+```
+
+### Building HIP Applications
+
+```bash
+docker run --rm -it \
+  -v $(pwd)/hip-source:/build \
+  batesste-ci-images-ubuntu-rocm:latest \
+  bash -c "cd /build && hipcc -o program program.cpp"
+```
+
+### Environment Variables
+
+The image sets up the following environment variables:
+
+- `PATH` - Includes `/opt/rocm/bin`
+- `LD_LIBRARY_PATH` - Includes `/opt/rocm/lib` and `/opt/rocm/lib64`
+- `ROCM_VERSION` - The ROCm version installed in the image
+
+### ROCm Library Paths
+
+The following library paths are configured:
+- `/opt/rocm/lib` - ROCm libraries
+- `/opt/rocm/lib64` - ROCm 64-bit libraries
+- `/opt/rocm/bin` - ROCm executables
+
+These paths are automatically added to `LD_LIBRARY_PATH` and `PATH`
+environment variables.
+
+## Version Detection
+
+When `ROCM_VERSION=latest` is specified (the default), the image uses
+the `rocm-latest` script to automatically detect the latest available
+ROCm version from the AMD repository. The script queries:
+- `https://repo.radeon.com/rocm/apt/` for ROCm versions
+- `https://repo.radeon.com/amdgpu/` for AMDGPU driver versions
+
+## Notes
+
+- This image is designed for CI/CD and development environments
+- For production GPU workloads, ensure proper GPU access is configured
+- The image includes ROCm repositories configured for Ubuntu 24.04
+- ROCm packages are pinned with priority 600 to ensure ROCm packages
+  are preferred over system packages

--- a/ubuntu-rocm/rocm-latest
+++ b/ubuntu-rocm/rocm-latest
@@ -1,0 +1,80 @@
+#!/bin/bash
+#
+# A simple bash script that uses curl to obtain the latest release of
+# ROCm and amdgpu packages via our packaging repo. Use QUIET=true to
+# only display the version tag. Use ONLY_ONE=[ROCM|AMDGPU] to only
+# output the version tag for either ROCm or amdgpu.
+#
+# Note that setting WSL_INSTALL=true ensures that only the latest
+# version that works with WSL2 is installed. This also will return
+# "none" for the amdgpu component as it is not used in WSL-based
+# systems. Note that we parse the RADEON_REPO tree to obtain this
+# latest version based on what version has the wsl version of the
+# runtime. Note the WSL_INSTALL version of this script can take longer
+# as it has to parse the website more.
+
+RADEON_REPO=${RADEON_REPO:-https://repo.radeon.com}
+QUIET=${QUIET:-false}
+ONLY_ONE=${ONLY_ONE:-false}
+WSL_INSTALL=${WSL_INSTALL:-false}
+
+ROCM_REMOTE=${RADEON_REPO}/rocm/apt/
+AMDGPU_REMOTE=${RADEON_REPO}/amdgpu/
+WSL_REMOTE=${RADEON_REPO}/amdgpu/
+
+wsl_version () {
+    VERSIONS=$(curl -s ${1} | \
+      sed -nE 's/^<a href="([0-9.]+*)\/">*.*/\1/p' | \
+      sort -rg)
+    mapfile -t VERSION_ARRAY <<< "${VERSIONS}"
+    WSL_SUPPORT="none"
+    for VERSION in "${VERSION_ARRAY[@]}"; do
+        if curl -s ${1}${VERSION}/ubuntu/pool/main/h/ | grep -qi wsl; then
+            WSL_SUPPORT=${VERSION}
+            break
+        fi
+    done
+    echo ${WSL_SUPPORT}
+}
+
+parse_repo () {
+    VERSION=$(curl -s ${1} | \
+      sed -nE 's/^<a href="([0-9.]+*)\/">*.*/\1/p' | \
+      sort -g | tail -n 1)
+    echo $VERSION
+}
+
+if [ ${ONLY_ONE} != "AMDGPU" ]; then
+
+    if [ ${WSL_INSTALL} == "true" ]; then
+        ROCM_VERSION=$(wsl_version $WSL_REMOTE)
+    else
+        ROCM_VERSION=$(parse_repo $ROCM_REMOTE)
+    fi
+    if [ ${QUIET} == "true" ]; then
+        echo ${ROCM_VERSION}
+    else
+        if [ ${WSL_INSTALL} == "true" ]; then
+            echo "ROCm latest (wsl): ${ROCM_VERSION}."
+        else
+            echo "ROCm latest: ${ROCM_VERSION}."
+        fi
+    fi
+fi
+
+if [ ${ONLY_ONE} != "ROCM" ]; then
+    if [ ${WSL_INSTALL} == "true" ]; then
+        AMDGPU_VERSION="none"
+    else
+        AMDGPU_VERSION=$(parse_repo $AMDGPU_REMOTE)
+    fi
+    if [ ${QUIET} == "true" ]; then
+        echo ${AMDGPU_VERSION}
+    else
+        if [ ${WSL_INSTALL} == "true" ]; then
+            echo "AMDGPU latest (wsl): ${AMDGPU_VERSION}."
+        else
+            echo "AMDGPU latest: ${AMDGPU_VERSION}."
+        fi
+    fi
+fi


### PR DESCRIPTION
It can be super-useful to have a container that has a certain version of ROCm installed. So implement this.