### PR TITLE
Add QEMU_REPO build arg for fork-based CI images

### DIFF
--- a/.github/workflows/dockerfile-test.yml
+++ b/.github/workflows/dockerfile-test.yml
@@ -45,24 +45,43 @@ jobs:
     needs: discover-images
     strategy:
       matrix:
-        image: ${{ fromJson(needs.discover-images.outputs.images) }}
+        image: >-
+          ${{
+            fromJson(
+              needs.discover-images.outputs.images
+            )
+          }}
+        variant: ['']
+        include:
+          - image: ubuntu-qemu-libvfio-user
+            variant: '-sbates-fork'
+            qemu_repo: >-
+              https://github.com/sbates130272/qemu.git
+            qemu_commit: >-
+              dev/stephen/pci-mmio-bridge-submit
     steps:
       - uses: actions/checkout@v4
 
       - name: Ensure cloud image cache dir exists
         run: |
-          mkdir -p "${{ matrix.image }}/cloud-image-cache"
+          mkdir -p \
+            "${{ matrix.image }}/cloud-image-cache"
 
       - name: Cache Ubuntu cloud image
-        if: matrix.image == 'ubuntu-qemu-libvfio-user'
+        if: >-
+          matrix.image ==
+          'ubuntu-qemu-libvfio-user'
         uses: actions/cache@v4
         with:
-          path: ${{ matrix.image }}/cloud-image-cache
+          path: >-
+            ${{ matrix.image }}/cloud-image-cache
           key: cloud-image-noble-amd64
           restore-keys: cloud-image-noble-
 
       - name: Pre-download cloud image
-        if: matrix.image == 'ubuntu-qemu-libvfio-user'
+        if: >-
+          matrix.image ==
+          'ubuntu-qemu-libvfio-user'
         run: |
           DIR="${{ matrix.image }}/cloud-image-cache"
           IMG="${DIR}/noble-server-cloudimg-amd64.img"
@@ -81,11 +100,27 @@ jobs:
           file: ${{ matrix.image }}/Dockerfile
           push: false
           load: true
-          tags: batesste-ci-images-${{ matrix.image }}:test
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          tags: >-
+            batesste-ci-images-${{
+              matrix.image
+            }}${{
+              matrix.variant
+            }}:test
+          cache-from: >-
+            type=gha,scope=${{
+              matrix.image
+            }}${{
+              matrix.variant
+            }}
+          cache-to: >-
+            type=gha,mode=max,scope=${{
+              matrix.image
+            }}${{
+              matrix.variant
+            }}
           build-args: |
-            QEMU_COMMIT=v10.2.2
+            QEMU_REPO=${{ matrix.qemu_repo || 'https://gitlab.com/qemu-project/qemu.git' }}
+            QEMU_COMMIT=${{ matrix.qemu_commit || 'v10.2.2' }}
             ${{ matrix.image == 'ubuntu-qemu-libvfio-user' && 'LIBVFIO_USER_COMMIT=082925c65d98021af5c0f36f60a98e0bb6ddb329' || '' }}
             ${{ matrix.image == 'ubuntu-qemu-libvfio-user' && 'QEMU_MINIMAL_REPO=https://github.com/sbates130272/qemu-minimal.git' || '' }}
             ${{ matrix.image == 'ubuntu-qemu-libvfio-user' && 'QEMU_MINIMAL_COMMIT=30c6d09265db2817f82e495aa5609e03fd0194a9' || '' }}
@@ -93,13 +128,24 @@ jobs:
       - name: Export Docker image
         run: |
           docker save \
-            "batesste-ci-images-${{ matrix.image }}:test" \
-            | gzip > "/tmp/${{ matrix.image }}.tar.gz"
+            "batesste-ci-images-${{ matrix.image }}${{ matrix.variant }}:test" \
+            | gzip \
+            > "/tmp/${{ matrix.image }}${{ matrix.variant }}.tar.gz"
 
       - uses: actions/upload-artifact@v4
         with:
-          name: docker-image-${{ matrix.image }}
-          path: /tmp/${{ matrix.image }}.tar.gz
+          name: >-
+            docker-image-${{
+              matrix.image
+            }}${{
+              matrix.variant
+            }}
+          path: >-
+            /tmp/${{
+              matrix.image
+            }}${{
+              matrix.variant
+            }}.tar.gz
           retention-days: 1
 
   test-entrypoint:
@@ -108,52 +154,81 @@ jobs:
     needs: [discover-images, build]
     strategy:
       matrix:
-        image: ${{ fromJson(needs.discover-images.outputs.images) }}
+        image: >-
+          ${{
+            fromJson(
+              needs.discover-images.outputs.images
+            )
+          }}
+        variant: ['']
+        include:
+          - image: ubuntu-qemu-libvfio-user
+            variant: '-sbates-fork'
     steps:
       - uses: actions/checkout@v4
 
       - name: Check if entrypoint.sh exists
         id: check-entrypoint
         run: |
-          if [ -f "${{ matrix.image }}/entrypoint.sh" ]; then
-            echo "exists=true" >> $GITHUB_OUTPUT
+          if [ -f \
+            "${{ matrix.image }}/entrypoint.sh" \
+          ]; then
+            echo "exists=true" \
+              >> $GITHUB_OUTPUT
           else
-            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "exists=false" \
+              >> $GITHUB_OUTPUT
           fi
 
       - name: Download Docker image artifact
-        if: steps.check-entrypoint.outputs.exists == 'true'
+        if: >-
+          steps.check-entrypoint.outputs.exists
+          == 'true'
         uses: actions/download-artifact@v4
         with:
-          name: docker-image-${{ matrix.image }}
+          name: >-
+            docker-image-${{
+              matrix.image
+            }}${{
+              matrix.variant
+            }}
 
       - name: Load Docker image
-        if: steps.check-entrypoint.outputs.exists == 'true'
+        if: >-
+          steps.check-entrypoint.outputs.exists
+          == 'true'
         run: |
-          gunzip -c "${{ matrix.image }}.tar.gz" \
+          gunzip -c \
+            "${{ matrix.image }}${{ matrix.variant }}.tar.gz" \
             | docker load
 
       - name: Test entrypoint script syntax
-        if: steps.check-entrypoint.outputs.exists == 'true'
+        if: >-
+          steps.check-entrypoint.outputs.exists
+          == 'true'
         run: |
           docker run --rm --entrypoint /bin/bash \
-            "batesste-ci-images-${{ matrix.image }}:test" \
+            "batesste-ci-images-${{ matrix.image }}${{ matrix.variant }}:test" \
             -c "bash -n /build/entrypoint.sh && \
                 echo 'Entrypoint syntax OK'"
 
-      - name: Test entrypoint help (should show usage)
-        if: steps.check-entrypoint.outputs.exists == 'true'
+      - name: Test entrypoint help
+        if: >-
+          steps.check-entrypoint.outputs.exists
+          == 'true'
         run: |
           timeout 10 docker run --rm \
             --cap-add NET_ADMIN \
             -e USERNAME=testuser \
             -e VM_NAME=test-vm \
             -e SSH_PORT=2222 \
-            "batesste-ci-images-${{ matrix.image }}:test" \
+            "batesste-ci-images-${{ matrix.image }}${{ matrix.variant }}:test" \
             || true
 
       - name: Skip entrypoint test
-        if: steps.check-entrypoint.outputs.exists == 'false'
+        if: >-
+          steps.check-entrypoint.outputs.exists
+          == 'false'
         run: |
           echo "No entrypoint.sh found, skipping"
 

--- a/build-and-push.sh
+++ b/build-and-push.sh
@@ -65,6 +65,8 @@ Environment variables:
   REGISTRY_PASSWORD      Registry login password
   REGISTRY_PASSWORD_FILE File containing password
   WORKDIR                Working directory for build context
+  QEMU_REPO              QEMU git repo URL
+                         (default: gitlab upstream)
   QEMU_COMMIT            QEMU version/commit to build
                          (default: HEAD)
   QEMU_MINIMAL_REPO      Repository URL for minimal QEMU source
@@ -141,6 +143,7 @@ REGISTRY=${REGISTRY:-docker.io}
 REGISTRY_USERNAME=${REGISTRY_USERNAME:-}
 REGISTRY_PASSWORD=${REGISTRY_PASSWORD:-}
 REGISTRY_PASSWORD_FILE=${REGISTRY_PASSWORD_FILE:-}
+QEMU_REPO=${QEMU_REPO:-https://gitlab.com/qemu-project/qemu.git}
 QEMU_COMMIT=${QEMU_COMMIT:-v10.2.2}
 LIBVFIO_USER_COMMIT=${LIBVFIO_USER_COMMIT:-082925c65d98021af5c0f36f60a98e0bb6ddb329}
 
@@ -242,6 +245,7 @@ for IMAGE_DIR in "${IMAGE_DIRS[@]}"; do
     # Pass build args that may be used by some images
     # Add cache-bust arg if provided (useful for forcing rebuilds)
     BUILD_ARGS=(
+        --build-arg QEMU_REPO="${QEMU_REPO}"
         --build-arg QEMU_COMMIT="${QEMU_COMMIT}"
         --build-arg LIBVFIO_USER_COMMIT="${LIBVFIO_USER_COMMIT}"
         --build-arg QEMU_MINIMAL_REPO="${QEMU_MINIMAL_REPO:-}"

--- a/env.example
+++ b/env.example
@@ -10,9 +10,17 @@ VMEM=4096
 # QEMU Configuration
 QEMU_PATH=/opt/qemu/bin/
 
-# Repository Git refs (tags or commit hashes for reproducible builds)
-# QEMU: use a release tag (e.g. v10.2.2) or commit hash; tags are typically stable but not as strictly immutable as a full commit SHA
-# Tags: git ls-remote --tags https://gitlab.com/qemu-project/qemu.git
+# QEMU source repository
+# Default: https://gitlab.com/qemu-project/qemu.git
+# Set to a fork URL to build from a different repo
+QEMU_REPO=
+
+# Repository Git refs (tags or commit hashes for
+# reproducible builds)
+# QEMU: use a release tag (e.g. v10.2.2) or commit
+# hash; tags are typically stable but not as strictly
+# immutable as a full commit SHA
+# Tags: git ls-remote --tags <QEMU_REPO URL>
 QEMU_COMMIT=v10.2.2
 # libvfio-user: pin to a commit hash (no formal releases)
 # Latest: git ls-remote https://gitlab.com/qemu-project/libvfio-user.git HEAD

--- a/ubuntu-qemu-libvfio-user/Dockerfile
+++ b/ubuntu-qemu-libvfio-user/Dockerfile
@@ -33,6 +33,7 @@ RUN apt-get update && \
     && rm -rf /var/lib/apt/lists/*
 
 # Accept QEMU and libvfio-user tags or commit SHAs
+ARG QEMU_REPO=https://gitlab.com/qemu-project/qemu.git
 ARG QEMU_COMMIT=v10.2.2
 ARG LIBVFIO_USER_COMMIT=082925c65d98021af5c0f36f60a98e0bb6ddb329
 
@@ -53,7 +54,7 @@ RUN git clone --filter=blob:none \
     https://gitlab.com/qemu-project/libvfio-user.git \
     /build/libvfio-user && \
     cd /build/libvfio-user && \
-    git checkout ${LIBVFIO_USER_COMMIT} && \
+    git checkout "${LIBVFIO_USER_COMMIT}" && \
     git rev-parse HEAD \
         > /build/libvfio-user-commit.txt && \
     meson setup build && \
@@ -65,14 +66,14 @@ RUN git clone --filter=blob:none \
 RUN if echo "${QEMU_COMMIT}" | \
         grep -qE '^[0-9a-f]{7,40}$'; then \
         git clone --filter=blob:none \
-            https://gitlab.com/qemu-project/qemu.git \
+            "${QEMU_REPO}" \
             /build/qemu && \
         cd /build/qemu && \
-        git checkout ${QEMU_COMMIT}; \
+        git checkout "${QEMU_COMMIT}"; \
     else \
         git clone --depth 1 \
-            --branch ${QEMU_COMMIT} \
-            https://gitlab.com/qemu-project/qemu.git \
+            --branch "${QEMU_COMMIT}" \
+            "${QEMU_REPO}" \
             /build/qemu; \
     fi && \
     cd /build/qemu && \


### PR DESCRIPTION
Parameterize the QEMU source URL so the same Dockerfile can build from upstream or a fork. The CI matrix now produces a second ubuntu-qemu-libvfio-user variant ("-sbates-fork") built from the sbates130272/qemu fork at the dev/stephen/pci-mmio-bridge-submit branch.

Changes:
- Dockerfile: add QEMU_REPO ARG, replace hardcoded URLs
- build-and-push.sh: pass QEMU_REPO as build arg
- env.example: document new QEMU_REPO variable
- CI workflow: add variant matrix dimension with include for the fork; scope GHA cache per variant; update test-entrypoint to cover both variants