### PR TITLE
Optimize CI image startup: KVM passthrough and qcow2/runtime slimming

### DIFF
--- a/.github/workflows/dockerfile-test.yml
+++ b/.github/workflows/dockerfile-test.yml
@@ -217,7 +217,15 @@ jobs:
           steps.check-entrypoint.outputs.exists
           == 'true'
         run: |
+          KVM_ARGS=""
+          if [ -c /dev/kvm ]; then
+            KVM_ARGS="--device /dev/kvm"
+            echo "KVM available: enabling /dev/kvm pass-through"
+          else
+            echo "KVM not available: using TCG emulation"
+          fi
           timeout 10 docker run --rm \
+            ${KVM_ARGS} \
             --cap-add NET_ADMIN \
             -e USERNAME=testuser \
             -e VM_NAME=test-vm \
@@ -264,7 +272,15 @@ jobs:
       - name: Start VM and wait for boot
         id: start-vm
         run: |
+          KVM_ARGS=""
+          if [ -c /dev/kvm ]; then
+            KVM_ARGS="--device /dev/kvm"
+            echo "KVM available: enabling /dev/kvm pass-through"
+          else
+            echo "KVM not available: using TCG emulation"
+          fi
           docker run -d --name test-vm-packages \
+            ${KVM_ARGS} \
             --cap-add NET_ADMIN \
             batesste-ci-images-ubuntu-qemu-libvfio-user:test
           echo "Waiting for VM to boot..."

--- a/README.md
+++ b/README.md
@@ -338,6 +338,43 @@ docker run --rm \
 Or mount the `/output` directory when running the container to access both the
 VM image and metadata file.
 
+### Performance Notes for GitHub Actions
+
+If this image is used as the container image for CI in another repository, the
+largest bottlenecks are usually image pull time and VM boot time.
+
+#### 1. KVM Acceleration on GitHub Runners
+
+KVM can be used when the runner exposes `/dev/kvm` and you pass it through to
+the container:
+
+```bash
+docker run --rm --device /dev/kvm ...
+```
+
+In workflows, always detect `/dev/kvm` first and fall back to TCG when it is
+not present. This repository's Dockerfile test workflow now does this
+automatically.
+
+#### 2. Smaller Embedded qcow2 Artifacts
+
+The `ubuntu-qemu-libvfio-user` image supports qcow2 compression during build
+with:
+
+```bash
+COMPRESS_VM_QCOW2=true
+```
+
+Compression is enabled by default and reduces registry transfer size for image
+pulls. If your workload is more sensitive to VM disk CPU overhead than pull
+time, set `COMPRESS_VM_QCOW2=false`.
+
+#### 3. Runtime Image Size Reduction
+
+The Dockerfile removes build-only dependencies after QEMU and VM image build so
+the final image carries less toolchain bloat. This improves pull/start latency
+for downstream CI jobs.
+
 ## Adding New Images
 
 To add a new image:

--- a/ci-images-tool.py
+++ b/ci-images-tool.py
@@ -35,6 +35,7 @@ DEFAULT_USERNAME = "batesste"
 DEFAULT_PASSWORD = "changeme"
 DEFAULT_RELEASE = "noble"
 DEFAULT_ARCH = "amd64"
+DEFAULT_COMPRESS_VM_QCOW2 = "true"
 
 ENV_SEARCH_PATHS = [
     ".env",
@@ -67,6 +68,7 @@ class Config:
     password: str = DEFAULT_PASSWORD
     release: str = DEFAULT_RELEASE
     arch: str = DEFAULT_ARCH
+    compress_vm_qcow2: str = DEFAULT_COMPRESS_VM_QCOW2
 
 
 def _resolve_password(
@@ -152,6 +154,10 @@ def load_config(
         password=os.environ.get("PASSWORD", DEFAULT_PASSWORD),
         release=os.environ.get("RELEASE", DEFAULT_RELEASE),
         arch=os.environ.get("ARCH", DEFAULT_ARCH),
+        compress_vm_qcow2=os.environ.get(
+            "COMPRESS_VM_QCOW2",
+            DEFAULT_COMPRESS_VM_QCOW2,
+        ),
     )
 
     cfg.registry_password = _resolve_password(password_file, cfg)
@@ -318,6 +324,7 @@ def cmd_build(args: argparse.Namespace) -> None:
             f"PASSWORD={cfg.password}",
             f"RELEASE={cfg.release}",
             f"ARCH={cfg.arch}",
+            f"COMPRESS_VM_QCOW2={cfg.compress_vm_qcow2}",
         ]
         if args.cache_bust:
             build_args.append(f"CACHE_BUST={args.cache_bust}")
@@ -384,6 +391,7 @@ def _print_build_summary(
         table.add_row("Cache Bust", args.cache_bust)
     if args.no_cache:
         table.add_row("No Cache", "true")
+    table.add_row("Compress VM qcow2", cfg.compress_vm_qcow2)
     console.print(table)
 
 

--- a/env.example
+++ b/env.example
@@ -33,6 +33,11 @@ QEMU_MINIMAL_PATH=/build/qemu-minimal
 QEMU_MINIMAL_COMMIT=
 QEMU_MINIMAL_REPO=
 
+# VM image optimization
+# Compress qcow2 output during image build to reduce OCI image transfer size
+# Set to false if you prefer faster local VM disk I/O over smaller pulls
+COMPRESS_VM_QCOW2=true
+
 # OCI Registry Configuration (for pushing Docker images)
 # Leave empty to skip pushing
 REGISTRY=docker.io

--- a/ubuntu-qemu-libvfio-user/Dockerfile
+++ b/ubuntu-qemu-libvfio-user/Dockerfile
@@ -46,6 +46,7 @@ ARG PASSWORD=changeme
 ARG RELEASE=noble
 ARG ARCH=amd64
 ARG CACHE_BUST=
+ARG COMPRESS_VM_QCOW2=true
 
 WORKDIR /build
 
@@ -86,6 +87,8 @@ RUN ./configure --target-list=x86_64-softmmu \
                 --prefix=/opt/qemu && \
     make -j$(nproc) && \
     make install && \
+    strip /opt/qemu/bin/qemu-system-* \
+        /opt/qemu/bin/qemu-img || true && \
     rm -rf /build/qemu
 
 # Install cloud-init utilities for VM creation
@@ -214,8 +217,22 @@ RUN --mount=type=bind,source=cloud-image-cache,target=/tmp/cloud-cache \
         [ -f "${IMAGES}/${FINAL_VM_NAME}.qcow2" ] || \
             { echo "Error: VM image not created!"; \
               ls -la "${IMAGES}/"; exit 1; }; \
-        cp "${IMAGES}/${FINAL_VM_NAME}.qcow2" \
-            /output/ && \
+        SOURCE_VM_IMAGE="${IMAGES}/${FINAL_VM_NAME}.qcow2"; \
+        FINAL_VM_IMAGE="${SOURCE_VM_IMAGE}"; \
+        if [ "${COMPRESS_VM_QCOW2}" = "true" ]; then \
+            echo "Compressing qcow2 image for smaller CI pulls..."; \
+            COMPRESSED_VM_IMAGE="/tmp/${FINAL_VM_NAME}.qcow2"; \
+            /opt/qemu/bin/qemu-img convert \
+                -f qcow2 \
+                -O qcow2 \
+                -c \
+                "${SOURCE_VM_IMAGE}" \
+                "${COMPRESSED_VM_IMAGE}"; \
+            FINAL_VM_IMAGE="${COMPRESSED_VM_IMAGE}"; \
+        fi; \
+        cp "${FINAL_VM_IMAGE}" \
+            "/output/${FINAL_VM_NAME}.qcow2" && \
+        rm -f /tmp/"${FINAL_VM_NAME}.qcow2" && \
         cp /root/.ssh/id_rsa /output/id_rsa \
             2>/dev/null || true; \
         cp /root/.ssh/id_rsa.pub /output/id_rsa.pub \
@@ -257,6 +274,22 @@ RUN --mount=type=bind,source=cloud-image-cache,target=/tmp/cloud-cache \
         rm -f /tmp/create_vm_info.py && \
         rm -rf "${QM}"; \
     fi
+
+# Remove build-only dependencies to reduce runtime image size
+RUN apt-get update && \
+    apt-get purge -y \
+    build-essential \
+    git \
+    ninja-build \
+    pkg-config \
+    libglib2.0-dev \
+    libpixman-1-dev \
+    libslirp-dev \
+    meson \
+    libjson-c-dev \
+    libcmocka-dev \
+    python3-venv \
+    && rm -rf /var/lib/apt/lists/*
 
 # Copy scripts
 COPY entrypoint.sh /build/entrypoint.sh


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add opportunistic `/dev/kvm` pass-through in Dockerfile CI tests so VM startup uses hardware acceleration whenever the runner provides KVM
- add `COMPRESS_VM_QCOW2` build arg (default `true`) to compress generated qcow2 images and reduce OCI pull size for downstream CI users
- strip installed QEMU binaries after build to reduce shipped image size
- purge build-only toolchain/dev packages after VM build to reduce runtime image bloat
- expose `COMPRESS_VM_QCOW2` through `ci-images-tool.py` and document it in `env.example`
- document GitHub Actions performance guidance (KVM detection + qcow2 tradeoffs) in top-level README

## Validation
- `python3 -m py_compile ci-images-tool.py`
- `bash -n ubuntu-qemu-libvfio-user/entrypoint.sh`
- reviewed git diff for workflow, Dockerfile, and docs consistency

## Notes
- runner/KVM behavior remains adaptive: workflow detects `/dev/kvm` and falls back to TCG automatically when unavailable.
- full docker build/run integration tests were not executed in this environment.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2fcf50b0-cd9d-4625-bb8f-190d93944bb4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2fcf50b0-cd9d-4625-bb8f-190d93944bb4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

