### PR TITLE
Add ubuntu-cuda-rocm dual GPU toolkit image on Ubuntu 24.04

### DIFF
--- a/.github/workflows/dockerfile-test.yml
+++ b/.github/workflows/dockerfile-test.yml
@@ -351,3 +351,41 @@ jobs:
             || true
           docker rm test-vm-packages 2>/dev/null \
             || true
+
+  test-gpu-toolchains:
+    name: Test GPU Toolchains (CUDA + ROCm)
+    runs-on: ubuntu-latest
+    needs: [discover-images, build]
+    if: >-
+      contains(
+        fromJson(needs.discover-images.outputs.images),
+        'ubuntu-cuda-rocm'
+      )
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download Docker image artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: docker-image-ubuntu-cuda-rocm
+
+      - name: Load Docker image
+        run: |
+          gunzip -c ubuntu-cuda-rocm.tar.gz \
+            | docker load
+
+      - name: Verify toolkit binaries and install paths
+        run: |
+          docker run --rm \
+            "batesste-ci-images-ubuntu-cuda-rocm:test" \
+            bash -lc '
+              set -e
+              echo "CUDA version file:"; cat /etc/cuda-version
+              echo "ROCm version file:"; cat /etc/rocm-version
+
+              echo "CUDA nvcc:"; which nvcc; nvcc --version
+              echo "ROCm hipcc:"; which hipcc; hipcc --version
+
+              test -d /opt/rocm
+              test -e /usr/local/cuda || test -n "$(ls -d /usr/local/cuda-* 2>/dev/null | head -n 1)"
+            '

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@
 **/cloud-image-cache/*.img
 # VSCode 
 .vscode
+# Python cache
+__pycache__/
+

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ and pushing of these images.
 - **ubuntu-kernel-build**: Ubuntu-based image with tools for building Linux
   kernels and out-of-tree kernel modules. See `ubuntu-kernel-build/` for
   details.
+- **ubuntu-cuda-rocm**: Toolkit-only dual-stack environment with CUDA and
+  ROCm/HIP tools on Ubuntu 24.04. See `ubuntu-cuda-rocm/` for details.
 
 ## Project Structure
 
@@ -24,6 +26,11 @@ batesste-ci-images/
 ├── ubuntu-kernel-build/       # Kernel build environment
 │   ├── Dockerfile
 │   └── README.md
+├── ubuntu-cuda-rocm/          # CUDA + ROCm toolchains
+│   ├── Dockerfile
+│   ├── README.md
+│   ├── cuda-latest
+│   └── rocm-latest
 ├── systemd/                   # Systemd service files
 │   ├── build-vm.service
 │   └── build-vm.timer
@@ -163,7 +170,8 @@ Common configuration variables:
 - `REGISTRY_PASSWORD`: Registry password or token for authentication
   - Can be a direct password or a path to a file containing the password
 - `REGISTRY_PASSWORD_FILE`: Alternative way to specify password file path
-- `IMAGE_TAG`: Image tag to use (default: `latest`)
+- `IMAGE_TAG`: Image tag to use (`auto` = today's date, e.g.
+  `may-26-2026`; set `latest` to pin that tag)
 - `WORKDIR`: Working directory for builds (defaults to script directory)
 
 The `ci-images-tool.py` CLI also supports:

--- a/ci-images-tool.py
+++ b/ci-images-tool.py
@@ -14,6 +14,7 @@ import argparse
 import os
 import subprocess
 import sys
+from datetime import datetime
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Optional
@@ -35,11 +36,28 @@ DEFAULT_USERNAME = "batesste"
 DEFAULT_PASSWORD = "changeme"
 DEFAULT_RELEASE = "noble"
 DEFAULT_ARCH = "amd64"
+DEFAULT_CUDA_VERSION = "latest"
+DEFAULT_ROCM_VERSION = "latest"
 
 ENV_SEARCH_PATHS = [
     ".env",
     "/etc/batesste-ci-images/.env",
 ]
+
+
+def resolve_image_tag(raw: Optional[str] = None) -> str:
+    """Return the effective OCI image tag.
+
+    When unset, empty, or set to ``auto``/``date``, use today's date in the
+    form ``may-26-2026``. Otherwise return the provided tag (e.g. ``latest``).
+    """
+
+    if raw is None:
+        raw = os.environ.get("IMAGE_TAG", "")
+    tag = (raw or "").strip()
+    if not tag or tag.lower() in {"auto", "date"}:
+        return datetime.now().strftime("%B-%d-%Y").lower()
+    return tag
 
 
 # ── configuration ──────────────────────────────────────
@@ -67,6 +85,8 @@ class Config:
     password: str = DEFAULT_PASSWORD
     release: str = DEFAULT_RELEASE
     arch: str = DEFAULT_ARCH
+    cuda_version: str = DEFAULT_CUDA_VERSION
+    rocm_version: str = DEFAULT_ROCM_VERSION
 
 
 def _resolve_password(
@@ -133,7 +153,7 @@ def load_config(
         workdir = script_dir
 
     cfg = Config(
-        image_tag=os.environ.get("IMAGE_TAG", DEFAULT_IMAGE_TAG),
+        image_tag=resolve_image_tag(os.environ.get("IMAGE_TAG")),
         registry=os.environ.get("REGISTRY", DEFAULT_REGISTRY),
         registry_image=os.environ.get("REGISTRY_IMAGE", ""),
         registry_username=os.environ.get("REGISTRY_USERNAME", ""),
@@ -152,6 +172,8 @@ def load_config(
         password=os.environ.get("PASSWORD", DEFAULT_PASSWORD),
         release=os.environ.get("RELEASE", DEFAULT_RELEASE),
         arch=os.environ.get("ARCH", DEFAULT_ARCH),
+        cuda_version=os.environ.get("CUDA_VERSION", DEFAULT_CUDA_VERSION),
+        rocm_version=os.environ.get("ROCM_VERSION", DEFAULT_ROCM_VERSION),
     )
 
     cfg.registry_password = _resolve_password(password_file, cfg)
@@ -319,6 +341,11 @@ def cmd_build(args: argparse.Namespace) -> None:
             f"RELEASE={cfg.release}",
             f"ARCH={cfg.arch}",
         ]
+        if image_dir == "ubuntu-cuda-rocm":
+            build_args += [
+                f"CUDA_VERSION={cfg.cuda_version}",
+                f"ROCM_VERSION={cfg.rocm_version}",
+            ]
         if args.cache_bust:
             build_args.append(f"CACHE_BUST={args.cache_bust}")
 

--- a/env.example
+++ b/env.example
@@ -39,5 +39,10 @@ REGISTRY=docker.io
 REGISTRY_IMAGE=batesste-ci-images
 REGISTRY_USERNAME=
 REGISTRY_PASSWORD=
-IMAGE_TAG=latest
+# auto = today's date (e.g. may-26-2026); use "latest" to pin that tag
+IMAGE_TAG=auto
+
+# ubuntu-cuda-rocm (optional)
+CUDA_VERSION=latest
+ROCM_VERSION=latest
 

--- a/ubuntu-cuda-rocm/Dockerfile
+++ b/ubuntu-cuda-rocm/Dockerfile
@@ -1,0 +1,126 @@
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV UBUNTU_CODENAME=noble
+
+ARG CUDA_VERSION=latest
+ARG ROCM_VERSION=latest
+ARG CACHE_BUST=
+
+# Install base build dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    ca-certificates \
+    cmake \
+    curl \
+    git \
+    gnupg \
+    libssl-dev \
+    libstdc++-14-dev \
+    lsb-release \
+    pciutils \
+    python3-setuptools \
+    python3-wheel \
+    wget \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY cuda-latest rocm-latest /usr/local/bin/
+RUN chmod +x /usr/local/bin/cuda-latest /usr/local/bin/rocm-latest
+
+RUN echo "Cache bust: ${CACHE_BUST:-none}" > /tmp/cache_bust.txt
+
+# Resolve toolkit versions for traceability and installs
+RUN set -eux; \
+    if [ "${CUDA_VERSION}" = "latest" ]; then \
+        DETECTED_CUDA=$(QUIET=true /usr/local/bin/cuda-latest); \
+    else \
+        DETECTED_CUDA="${CUDA_VERSION}"; \
+    fi; \
+    echo "${DETECTED_CUDA}" > /etc/cuda-version; \
+    if [ "${ROCM_VERSION}" = "latest" ]; then \
+        DETECTED_ROCM=$(QUIET=true ONLY_ONE=ROCM /usr/local/bin/rocm-latest); \
+        ROCM_APT_PATH="latest"; \
+    else \
+        DETECTED_ROCM="${ROCM_VERSION}"; \
+        ROCM_APT_PATH="${ROCM_VERSION}"; \
+    fi; \
+    echo "${DETECTED_ROCM}" > /etc/rocm-version; \
+    echo "${ROCM_APT_PATH}" > /etc/rocm-apt-path
+
+# NVIDIA CUDA repository (ubuntu2404 / noble)
+RUN wget -q -O /tmp/cuda-keyring.deb \
+        https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/cuda-keyring_1.1-1_all.deb \
+    && dpkg -i /tmp/cuda-keyring.deb \
+    && rm -f /tmp/cuda-keyring.deb \
+    && apt-get update
+
+# AMD ROCm repository
+RUN curl -fsSL https://repo.radeon.com/rocm/rocm.gpg.key | \
+        gpg --dearmor -o /etc/apt/keyrings/rocm.gpg
+
+RUN ROCM_APT_PATH=$(cat /etc/rocm-apt-path) && \
+    cat <<EOF > /etc/apt/sources.list.d/rocm.list
+deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/${ROCM_APT_PATH} ${UBUNTU_CODENAME} main
+deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/amdgpu/${ROCM_APT_PATH}/ubuntu ${UBUNTU_CODENAME} main
+EOF
+
+RUN cat <<EOF > /etc/apt/preferences.d/rocm-pin-600
+Package: *
+Pin: release o=repo.radeon.com
+Pin-Priority: 600
+EOF
+
+# CUDA toolkit (dev only; no drivers)
+RUN set -eux; \
+    CUDA_PKG_VER=$(cat /etc/cuda-version); \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        "cuda-toolkit-${CUDA_PKG_VER}"; \
+    rm -rf /var/lib/apt/lists/*
+
+# ROCm development stack (dev only; no drivers)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    clang \
+    doxygen \
+    gdb \
+    hip-dev \
+    libboost-program-options-dev \
+    libmount-dev \
+    librocthrust-dev \
+    llvm-dev \
+    rocm-llvm-dev \
+    && update-pciids \
+    && rm -rf /var/lib/apt/lists/*
+
+# Linker configuration
+RUN cat <<EOF > /etc/ld.so.conf.d/rocm.conf
+/opt/rocm/lib
+/opt/rocm/lib64
+EOF
+
+RUN cat <<EOF > /etc/ld.so.conf.d/cuda.conf
+/usr/local/cuda/lib64
+EOF
+
+RUN ldconfig
+
+# Per-stack environment (avoid mixing LD_LIBRARY_PATH in Dockerfile ENV)
+RUN cat <<'EOF' > /etc/profile.d/cuda.sh
+# NVIDIA CUDA toolkit environment
+if [ -d /usr/local/cuda ]; then
+    export CUDA_HOME=/usr/local/cuda
+    export PATH="${CUDA_HOME}/bin:${PATH}"
+    export LD_LIBRARY_PATH="${CUDA_HOME}/lib64:${LD_LIBRARY_PATH:-}"
+fi
+EOF
+
+RUN cat <<'EOF' > /etc/profile.d/rocm.sh
+# AMD ROCm / HIP development environment
+export ROCM_PATH=/opt/rocm
+export PATH="${ROCM_PATH}/bin:${PATH}"
+export LD_LIBRARY_PATH="${ROCM_PATH}/lib:${ROCM_PATH}/lib64:${LD_LIBRARY_PATH:-}"
+EOF
+
+WORKDIR /build
+
+CMD ["/bin/bash"]

--- a/ubuntu-cuda-rocm/README.md
+++ b/ubuntu-cuda-rocm/README.md
@@ -1,0 +1,150 @@
+# ubuntu-cuda-rocm
+
+Toolkit-only dual-stack image for CUDA and ROCm on Ubuntu 24.04.
+
+## Overview
+
+This image is intended for CI/CD and developer workflows that need both
+toolchains available in one container:
+
+- CUDA toolkit (`nvcc`, libraries under `/usr/local/cuda`)
+- ROCm/HIP development stack (compiler tools under `/opt/rocm`)
+
+It is **toolkit-only**: GPU driver packages are not installed in the
+container. You typically provide drivers from the host.
+
+The image also avoids embedding a single mixed `LD_LIBRARY_PATH` in
+`Dockerfile` `ENV`. Instead, it provides per-stack environment scripts
+in `/etc/profile.d/`.
+
+## Base image
+
+- `ubuntu:24.04`
+
+## Installed toolchain components
+
+The exact CUDA and ROCm versions are selected via build args:
+
+- `CUDA_VERSION`
+- `ROCM_VERSION`
+
+For `latest`, the image uses:
+
+- `/usr/local/bin/cuda-latest` (NVIDIA repo parsing)
+- `/usr/local/bin/rocm-latest` (AMD repo parsing)
+
+Resolved values are written to:
+
+- `/etc/cuda-version`
+- `/etc/rocm-version`
+
+## Build arguments
+
+### `CUDA_VERSION`
+
+- Default: `latest`
+- Behavior:
+  - `latest` installs the highest `cuda-toolkit-M-N` available
+  - otherwise installs `cuda-toolkit-${CUDA_VERSION}`
+
+### `ROCM_VERSION`
+
+- Default: `latest`
+- Behavior:
+  - `latest` uses `latest` for both `/rocm/apt/` and `/amdgpu/` apt repos
+    (and still records the detected ROCm version for traceability)
+  - otherwise uses that value for both apt repos
+
+Note: the ROCm and amdgpu repo path version strings do not always match.
+If you find that a pinned `ROCM_VERSION` fails during `apt-get update`,
+try `ROCM_VERSION=latest`.
+
+### `CACHE_BUST`
+
+Optional build arg supported by this repo convention. It can be set to
+force rebuilds when you change scripts or logic.
+
+## Build
+
+### Default (latest)
+
+```bash
+docker build -f ubuntu-cuda-rocm/Dockerfile \
+  -t batesste-ci-images-ubuntu-cuda-rocm:latest \
+  ubuntu-cuda-rocm
+```
+
+### Pinned CUDA and ROCm
+
+```bash
+docker build -f ubuntu-cuda-rocm/Dockerfile \
+  --build-arg CUDA_VERSION=13-2 \
+  --build-arg ROCM_VERSION=latest \
+  -t batesste-ci-images-ubuntu-cuda-rocm:13-2-latest-rocm \
+  ubuntu-cuda-rocm
+```
+
+## Verify (no GPU required)
+
+Run these inside the container:
+
+```bash
+docker run --rm -it \
+  batesste-ci-images-ubuntu-cuda-rocm:latest \
+  bash -lc '
+    echo "CUDA:"; cat /etc/cuda-version;
+    nvcc --version || true;
+    echo;
+    echo "ROCm:"; cat /etc/rocm-version;
+    hipcc --version || true;
+    ls -la /opt/rocm || true;
+  '
+```
+
+Expected:
+
+- `nvcc --version` works (CUDA toolkit installed)
+- `hipcc --version` works (ROCm/HIP tools installed)
+
+## Runtime notes (GPU drivers are host-provided)
+
+### NVIDIA GPU usage
+
+Typical container run pattern (requires host NVIDIA drivers and
+nvidia-container-toolkit):
+
+```bash
+docker run --rm -it --gpus all \
+  batesste-ci-images-ubuntu-cuda-rocm:latest \
+  bash -lc "nvcc --version"
+```
+
+### AMD GPU usage
+
+Typical container run pattern for ROCm/HIP in a container
+(requires host AMD drivers and `/dev/kfd` + `/dev/dri`):
+
+```bash
+docker run --rm -it \
+  --device=/dev/kfd \
+  --device=/dev/dri \
+  --group-add video \
+  --security-opt seccomp=unconfined \
+  batesste-ci-images-ubuntu-cuda-rocm:latest \
+  bash -lc "hipcc --version"
+```
+
+## References
+
+<!-- References -->
+[nvidia-ubuntu2404-packages]:
+  https://developer.download.nvidia.com/compute/cuda/repos/
+  ubuntu2404/x86_64/Packages
+[nvidia-cuda-keyring]:
+  https://developer.download.nvidia.com/compute/cuda/repos/
+  ubuntu2404/x86_64/cuda-keyring_1.1-1_all.deb
+[amdgpu-rocm-apt]:
+  https://repo.radeon.com/rocm/apt/latest/
+[amdgpu-apt-base]:
+  https://repo.radeon.com/amdgpu/latest/ubuntu/
+

--- a/ubuntu-cuda-rocm/cuda-latest
+++ b/ubuntu-cuda-rocm/cuda-latest
@@ -1,0 +1,26 @@
+#!/bin/bash
+#
+# Query the NVIDIA CUDA apt repository for the highest cuda-toolkit-M-N
+# package version. Use QUIET=true to print only the M-N tag (e.g. 13-2).
+
+CUDA_REPO=${CUDA_REPO:-https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64}
+QUIET=${QUIET:-false}
+
+PACKAGES_URL="${CUDA_REPO}/Packages"
+
+LATEST=$(curl -fsSL "${PACKAGES_URL}" | \
+    awk '/^Package: cuda-toolkit-[0-9]+-[0-9]+$/{print $2}' | \
+    sed 's/^cuda-toolkit-//' | \
+    sort -V | \
+    tail -n 1)
+
+if [ -z "${LATEST}" ]; then
+    echo "cuda-latest: failed to detect cuda-toolkit version" >&2
+    exit 1
+fi
+
+if [ "${QUIET}" = "true" ]; then
+    echo "${LATEST}"
+else
+    echo "CUDA toolkit latest: ${LATEST}"
+fi

--- a/ubuntu-cuda-rocm/rocm-latest
+++ b/ubuntu-cuda-rocm/rocm-latest
@@ -1,0 +1,70 @@
+#!/bin/bash
+#
+# Obtain the latest ROCm and amdgpu package versions from repo.radeon.com.
+# Use QUIET=true to only display the version tag.
+# Use ONLY_ONE=[ROCM|AMDGPU] to output one version tag only.
+
+RADEON_REPO=${RADEON_REPO:-https://repo.radeon.com}
+QUIET=${QUIET:-false}
+ONLY_ONE=${ONLY_ONE:-false}
+WSL_INSTALL=${WSL_INSTALL:-false}
+
+ROCM_REMOTE=${RADEON_REPO}/rocm/apt/
+AMDGPU_REMOTE=${RADEON_REPO}/amdgpu/
+WSL_REMOTE=${RADEON_REPO}/amdgpu/
+
+wsl_version () {
+    VERSIONS=$(curl -s "${1}" | \
+      sed -nE 's/^<a href="([0-9.]+*)\/">*.*/\1/p' | \
+      sort -rg)
+    mapfile -t VERSION_ARRAY <<< "${VERSIONS}"
+    WSL_SUPPORT="none"
+    for VERSION in "${VERSION_ARRAY[@]}"; do
+        if curl -s "${1}${VERSION}/ubuntu/pool/main/h/" | grep -qi wsl; then
+            WSL_SUPPORT=${VERSION}
+            break
+        fi
+    done
+    echo "${WSL_SUPPORT}"
+}
+
+parse_repo () {
+    VERSION=$(curl -s "${1}" | \
+      sed -nE 's/^<a href="([0-9.]+*)\/">*.*/\1/p' | \
+      sort -g | tail -n 1)
+    echo "${VERSION}"
+}
+
+if [ "${ONLY_ONE}" != "AMDGPU" ]; then
+    if [ "${WSL_INSTALL}" = "true" ]; then
+        ROCM_VERSION=$(wsl_version "${WSL_REMOTE}")
+    else
+        ROCM_VERSION=$(parse_repo "${ROCM_REMOTE}")
+    fi
+    if [ "${QUIET}" = "true" ]; then
+        echo "${ROCM_VERSION}"
+    else
+        if [ "${WSL_INSTALL}" = "true" ]; then
+            echo "ROCm latest (wsl): ${ROCM_VERSION}."
+        else
+            echo "ROCm latest: ${ROCM_VERSION}."
+        fi
+    fi
+fi
+
+if [ "${ONLY_ONE}" != "ROCM" ]; then
+    if [ "${WSL_INSTALL}" = "true" ]; then
+        AMDGPU_VERSION="none"
+    else
+        AMDGPU_VERSION=$(parse_repo "${AMDGPU_REMOTE}")
+    fi
+    if [ "${QUIET}" = "true" ]; then
+        echo "${AMDGPU_VERSION}"
+    else
+        if [ "${WSL_INSTALL}" = "true" ]; then
+            echo "AMDGPU latest (wsl): ${AMDGPU_VERSION}."
+        else
+            echo "AMDGPU latest: ${AMDGPU_VERSION}."
+        fi
+    fi
+fi


### PR DESCRIPTION
Introduce a toolkit-only image that installs the latest CUDA toolkit and ROCm/HIP dev stack side by side for CI build workflows, without GPU driver packages in the container.

- Add ubuntu-cuda-rocm/ with Dockerfile, README, cuda-latest, and rocm-latest version probes
- Wire CUDA_VERSION and ROCM_VERSION build args in ci-images-tool.py
- Add CI smoke tests for nvcc, hipcc, and install paths
- Document the image in the top-level README and env.example
- Resolve IMAGE_TAG=auto to today's date (e.g. may-26-2026)
- Ignore __pycache__/ in .gitignore