### PR TITLE
feat(ubuntu-qemu-libvfio-user): pre-install RDMA build deps in VM dis…

### DIFF
--- a/.github/workflows/dockerfile-test.yml
+++ b/.github/workflows/dockerfile-test.yml
@@ -297,7 +297,7 @@ jobs:
             2>/dev/null || echo "")
           echo "Container kernel: ${KERNEL_VERSION}"
           MISSING_PACKAGES=""
-          for PKG in build-essential rdma-core; do
+          for PKG in build-essential rdma-core ibverbs-utils libibverbs-dev cmake ninja-build pkg-config; do
             echo "Checking for ${PKG}..."
             if docker exec test-vm-packages bash -c \
               "chmod 600 /output/id_rsa && \

--- a/ci-images-tool.py
+++ b/ci-images-tool.py
@@ -14,10 +14,9 @@ import argparse
 import os
 import subprocess
 import sys
-from datetime import datetime
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from pathlib import Path
-from typing import Optional
 
 import docker
 import requests
@@ -45,7 +44,7 @@ ENV_SEARCH_PATHS = [
 ]
 
 
-def resolve_image_tag(raw: Optional[str] = None) -> str:
+def resolve_image_tag(raw: str | None = None) -> str:
     """Return the effective OCI image tag.
 
     When unset, empty, or set to ``auto``/``date``, use today's date in the
@@ -56,7 +55,7 @@ def resolve_image_tag(raw: Optional[str] = None) -> str:
         raw = os.environ.get("IMAGE_TAG", "")
     tag = (raw or "").strip()
     if not tag or tag.lower() in {"auto", "date"}:
-        return datetime.now().strftime("%B-%d-%Y").lower()
+        return datetime.now(tz=timezone.utc).strftime("%B-%d-%Y").lower()
     return tag
 
 
@@ -90,13 +89,13 @@ class Config:
 
 
 def _resolve_password(
-    password_file_cli: Optional[str],
+    password_file_cli: str | None,
     cfg: Config,
 ) -> str:
     """Resolve registry password: CLI file > env file >
     env literal.  Mirrors the shell script precedence."""
 
-    pw_file: Optional[str] = None
+    pw_file: str | None = None
 
     if password_file_cli:
         pw_file = password_file_cli
@@ -118,8 +117,8 @@ def _resolve_password(
 
 
 def load_config(
-    env_file: Optional[str] = None,
-    password_file: Optional[str] = None,
+    env_file: str | None = None,
+    password_file: str | None = None,
 ) -> Config:
     """Load .env then populate a Config from the
     environment, applying defaults."""
@@ -193,7 +192,7 @@ def discover_images(workdir: Path) -> list[str]:
     return dirs
 
 
-def resolve_image_dirs(workdir: Path, image_arg: Optional[str]) -> list[str]:
+def resolve_image_dirs(workdir: Path, image_arg: str | None) -> list[str]:
     """If the caller specified a single image name, return
     it; otherwise discover all."""
     if image_arg:
@@ -227,7 +226,7 @@ def full_image_ref(cfg: Config, image_dir: str) -> str:
     return name
 
 
-def tagged_ref(cfg: Config, image_dir: str, tag: Optional[str] = None) -> str:
+def tagged_ref(cfg: Config, image_dir: str, tag: str | None = None) -> str:
     """Full registry/name:tag string."""
     t = tag or cfg.image_tag
     name = full_image_ref(cfg, image_dir)
@@ -265,11 +264,13 @@ def ensure_builder() -> None:
         ],
         capture_output=True,
         text=True,
+        check=False,
     )
     use_proc = subprocess.run(
         ["docker", "buildx", "use", "builder"],
         capture_output=True,
         text=True,
+        check=False,
     )
     if use_proc.returncode != 0:
         console.print(
@@ -529,7 +530,7 @@ def _registry_base_url(registry: str) -> str:
     return registry
 
 
-def _docker_hub_token(repo: str) -> Optional[str]:
+def _docker_hub_token(repo: str) -> str | None:
     """Obtain a Docker Hub bearer token for public
     read access."""
     url = (

--- a/ubuntu-qemu-libvfio-user/Dockerfile
+++ b/ubuntu-qemu-libvfio-user/Dockerfile
@@ -3,14 +3,6 @@ FROM ubuntu:24.04
 # Avoid interactive prompts during package installation
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Install AMD/Zscaler corporate CA so apt-get, git, wget, curl
-# all work through the TLS-inspecting proxy on this build node.
-COPY amd-root-ca.crt /usr/local/share/ca-certificates/amd-root-ca.crt
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends ca-certificates && \
-    update-ca-certificates && \
-    rm -rf /var/lib/apt/lists/*
-
 # Install build dependencies for QEMU and libvfio-user
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \

--- a/ubuntu-qemu-libvfio-user/Dockerfile
+++ b/ubuntu-qemu-libvfio-user/Dockerfile
@@ -1,8 +1,15 @@
-# syntax=docker/dockerfile:1
 FROM ubuntu:24.04
 
 # Avoid interactive prompts during package installation
 ENV DEBIAN_FRONTEND=noninteractive
+
+# Install AMD/Zscaler corporate CA so apt-get, git, wget, curl
+# all work through the TLS-inspecting proxy on this build node.
+COPY amd-root-ca.crt /usr/local/share/ca-certificates/amd-root-ca.crt
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates && \
+    update-ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
 
 # Install build dependencies for QEMU and libvfio-user
 RUN apt-get update && \

--- a/ubuntu-qemu-libvfio-user/packages.txt
+++ b/ubuntu-qemu-libvfio-user/packages.txt
@@ -2,3 +2,8 @@ build-essential
 linux-headers-${KERNEL_VERSION}
 linux-modules-extra-${KERNEL_VERSION}
 rdma-core
+ibverbs-utils
+libibverbs-dev
+cmake
+ninja-build
+pkg-config


### PR DESCRIPTION
…k image

Add ibverbs-utils, libibverbs-dev, cmake, ninja-build, and pkg-config to packages.txt so they are baked into the VM disk image at build time rather than installed at CI runtime inside the slow TCG-emulated VMs.

Also install the AMD Corporate Root CA in the Dockerfile so that git, apt, wget, and curl work through the Zscaler TLS-intercepting proxy on AMD build nodes. The # syntax=docker/dockerfile:1 directive is removed so BuildKit does not attempt a network fetch before the FROM layer executes.

Update dockerfile-test.yml to verify all seven expected packages are present in the booted VM, so regressions are caught by CI.